### PR TITLE
Fix: Correction erreur 500 lors de l'accès à la configuration (#9)

### DIFF
--- a/custom_components/hass_vivreco_pac/config_flow.py
+++ b/custom_components/hass_vivreco_pac/config_flow.py
@@ -72,20 +72,20 @@ class VivrecoOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialiser le flux d'options."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Gérer les options."""
         if user_input is not None:
             # Mettre à jour les données de l'entrée de configuration
             self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data={**self.config_entry.data, **user_input},
+                self._config_entry,
+                data={**self._config_entry.data, **user_input},
             )
             return self.async_create_entry(title="", data={})
 
         # Récupérer la valeur actuelle
-        current_interval = self.config_entry.data.get(
+        current_interval = self._config_entry.data.get(
             CONF_SCAN_INTERVAL, DEFAULT_UPDATE_INTERVAL
         )
 

--- a/custom_components/hass_vivreco_pac/manifest.json
+++ b/custom_components/hass_vivreco_pac/manifest.json
@@ -9,5 +9,5 @@
     "issue_tracker": "https://github.com/fab5741/hass-vivreco-pac/issues",
     "requirements": ["aiohttp"],
     "single_config_entry": true,
-    "version": "2.0.0"
+    "version": "2.0.1"
 }


### PR DESCRIPTION
## 🎯 Objectif

Correction de l'erreur 500 (AttributeError) qui empêchait l'accès à la fenêtre de configuration de l'intégration via l'UI (Settings > Devices & Services > Vivreco PAC > Configure).

## 🐛 Problème

L'erreur se produisait à la ligne 75 de `config_flow.py` :
```
AttributeError: property 'config_entry' of 'VivrecoOptionsFlow' object has no setter
```

### Cause
Le code tentait d'assigner directement `self.config_entry = config_entry` dans le `__init__` de `VivrecoOptionsFlow`. Or `config_entry` est une propriété en lecture seule héritée de la classe de base `config_entries.OptionsFlow`, donc cette assignation échouait.

## ✅ Solution

Utilisation d'un attribut d'instance privé `self._config_entry` au lieu de tenter d'assigner à la propriété protégée. Cette modification a été appliquée dans :
- `__init__` : stockage de la référence
- `async_step_init` : utilisation de `self._config_entry` pour accéder aux données

## 📝 Changements

- **config_flow.py** : `self.config_entry` → `self._config_entry` (4 occurrences)
- **manifest.json** : version `2.0.0` → `2.0.1`

## 🧪 Test plan

- [ ] Vérifier que l'intégration s'installe correctement
- [ ] Accéder à Settings > Devices & Services > Vivreco PAC
- [ ] Cliquer sur Configure (icône engrenage)
- [ ] Vérifier que la fenêtre de configuration s'ouvre sans erreur 500
- [ ] Modifier l'intervalle de scan et vérifier que la modification est prise en compte

## 📎 Liens

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)